### PR TITLE
Update ZoneGroupTools.lua

### DIFF
--- a/src/ZoneDaemon/ZoneGroupTools.lua
+++ b/src/ZoneDaemon/ZoneGroupTools.lua
@@ -1,5 +1,5 @@
-local EnumList = require(script.Parent.EnumList)
-local TableUtil = require(script.Parent.TableUtil)
+local EnumList = require(script.EnumList)
+local TableUtil = require(script.TableUtil)
 
 local HttpService = game:GetService("HttpService")
 


### PR DESCRIPTION
Adopts the Roblox styling guide and uses updated Trove API. Instead of passing a Trove, you can just do ``Trove:Construct(Zone, zonePart)``.