### PR TITLE
Possible fix for #15 - ZoneDaemon no longer leaks memory

### DIFF
--- a/src/ZoneDaemon/init.lua
+++ b/src/ZoneDaemon/init.lua
@@ -471,11 +471,7 @@ function ZoneDaemon:GetPlayers(): Array<Player>
 end
 
 function ZoneDaemon:SetParams(overlapParams: OverlapParams | nil): nil
-	if overlapParams then
-		self._overrideParams = overlapParams
-	else
-		self._overrideParams = nil
-	end
+	self._overrideParams = overlapParams
 end
 
 return ZoneDaemon


### PR DESCRIPTION
This is a possible fix for #15. Instead of creating new tables each frame for IntersectParts and NewParts, we now have a private member of the class that is cleared if there is no conflicting frames. Additionally, redundancy and bad-practices have been removed in order to keep the module in line with the Roblox Lua style guide.